### PR TITLE
feat: containerize tttakedown-tracker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+Dockerfile
+.gitignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG YT_DLP_VERSION=2023.12.30 \
+  FFMPEG_VERSION=autobuild-2024-02-02-15-50
+
+FROM denoland/deno:alpine
+
+ARG YT_DLP_VERSION \
+  FFMPEG_VERSION
+# install ffmpeg, yt-dlp, and tubeup
+RUN wget -qO- https://github.com/yt-dlp/FFmpeg-Builds/releases/download/${FFMPEG_VERSION}/ffmpeg-n6.1.1-1-g61b88b4dda-linux64-gpl-6.1.tar.xz \
+  | tar xfJ - -C /bin --strip-components 2 "ffmpeg-n6.1.1-1-g61b88b4dda-linux64-gpl-6.1/bin/ffmpeg" "ffmpeg-n6.1.1-1-g61b88b4dda-linux64-gpl-6.1/bin/ffprobe" \
+  && wget https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp_linux -O /bin/yt-dlp \
+  && chmod a+rx /bin/yt-dlp \
+  && apk add --no-cache python3 py3-pip \
+  && python3 -m pip install -U pip tubeup
+
+WORKDIR /app
+
+COPY deno.lock deps.ts ./
+RUN deno cache --lock=deno.lock deps.ts
+
+COPY . .
+
+CMD ["deno", "run", "-A", "main.ts"]
+STOPSIGNAL SIGINT
+
+VOLUME ["/app/data"]

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,2 @@
+export type { Embed } from 'https://deno.land/x/dishooks@v1.1.0/mod.ts'
+export { post } from 'https://deno.land/x/dishooks@v1.1.0/mod.ts'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.7'
+services:
+  tttakedown-tracker:
+    build: .
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./data:/app/data
+    restart: unless-stopped

--- a/downloadData.ts
+++ b/downloadData.ts
@@ -30,7 +30,7 @@ const instancesPromise = (async () => {
     .filter(([_domain, data]) =>
       data.api &&
       data.type === 'https' &&
-      data.monitor.statusClass === 'success' &&
+      data.monitor?.statusClass === 'success' &&
       data.region === 'US' &&
       Number(data.monitor['30dRatio'].ratio) > 97
     )
@@ -245,15 +245,17 @@ type invidiousInstancesData = [string, {
   api: boolean
   type: string
   uri: string
-  monitor: {
-    monitorId: number
-    createdAt: number
-    statusClass: string
-    name: string
-    url: null
-    type: string
-    dailyRatios: { ratio: string; label: string }[]
-    '90dRatio': { ratio: string; label: string }
-    '30dRatio': { ratio: string; label: string }
-  }
+  monitor:
+    | null
+    | {
+      monitorId: number
+      createdAt: number
+      statusClass: string
+      name: string
+      url: null
+      type: string
+      dailyRatios: { ratio: string; label: string }[]
+      '90dRatio': { ratio: string; label: string }
+      '30dRatio': { ratio: string; label: string }
+    }
 }][]

--- a/reportChanges.ts
+++ b/reportChanges.ts
@@ -1,4 +1,4 @@
-import { type Embed, post } from 'https://deno.land/x/dishooks@v1.1.0/mod.ts'
+import { type Embed, post } from './deps.ts'
 import config from './config.json' with { type: 'json' }
 import { chunkArray, random } from './helpers.ts'
 import type { change } from './video.ts'


### PR DESCRIPTION
Make it works in docker

I didn't test the code fully with a working configuration soo do check if it works first before merging the pull request

# How to run in docker
Make sure your `data` folder exists and have a valid `config.json` configuration
After that, run:
```sh
docker compose up -d
```
The application is now running in the background

# Helpful links
Installing docker: https://docs.docker.com/engine/install/
Starting it: https://docs.docker.com/engine/reference/commandline/compose_up/
Shutting it down: https://docs.docker.com/engine/reference/commandline/compose_down/
Check logs: https://docs.docker.com/engine/reference/commandline/compose_logs/